### PR TITLE
Fix graphql query

### DIFF
--- a/src/components/image.js
+++ b/src/components/image.js
@@ -33,11 +33,15 @@ import Img from 'gatsby-image';
 // );
 // export default Image;
 
-export const DunderImage = () => (
+// COMMENTS FROM JOEEEEEEE
+// Gatsby exports a default export
+
+// Also the query you wrote needed a small change. You basically had it right, minius the fileName part.
+const DunderImage = () => (
   <StaticQuery
     query={graphql`
       query {
-        placeholderImage: file(relativePath: { eq: "dunderIpsum-550.png" }) {
+        fileName: file(relativePath: { eq: "dunderIpsum-550.png"}) {
           childImageSharp {
             fluid(maxWidth: 550) {
               ...GatsbyImageSharpFluid
@@ -46,11 +50,16 @@ export const DunderImage = () => (
         }
       }
     `}
-    render={(data) => (
-      <Img fluid={data.placeholderImage.childImageSharp.fluid} />
-    )}
+    render={(data) => {
+
+      return (
+        <Img fluid={data.fileName.childImageSharp.fluid} />
+      )
+  }}
   />
 );
+
+export default DunderImage
 
 // export const query = graphql`
 //   query {
@@ -79,3 +88,4 @@ export const DunderImage = () => (
 //     }
 //   }
 // `;
+

--- a/src/pages/Portfolio.js
+++ b/src/pages/Portfolio.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Img } from 'gatsby-image';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import DunderImage from '../images/dunderIpsum-550.png';
+import DunderImage from '../components/image';
 
 const SecondPage = ({ data }) => (
   <Layout>


### PR DESCRIPTION
So two main things:

- you were basically there, you just had to import the `<image />` component instead of importing the file directly into the Portfolio page.

- the GraphQL query needed a bit of tweaking.

For reference, I solved the query by looking [here](https://www.gatsbyjs.org/docs/working-with-images/) + my previous experience.

For the other issue, the console was logging an error about the Portfolio page so I figured out the image wasn't being use correctly.

Hope that helps! 👍 

Also, if you want to have a more "dynamic" component since you have multiple screenshots, look at this [Spectrum thread](https://spectrum.chat/gatsby-js/general/using-variables-in-a-staticquery~abee4d1d-6bc4-4202-afb2-38326d91bd05) from Wes Bos. I used Wes' solution in a freelance project and it works well!